### PR TITLE
fix: broken metrics format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export const serverTiming = ({
 				if (traceHandle)
 					onHandle(({ name, onStop }) => {
 						onStop(({ elapsed }) => {
-							label += `handle.${name};dur=${elapsed}`
+							label += `handle.${name};dur=${elapsed},`
 						})
 					})
 
@@ -184,6 +184,7 @@ export const serverTiming = ({
 						if (allowed instanceof Promise) allowed = await allowed
 
 						if (traceTotal) label += `total;dur=${end - start}`
+						else label = label.slice(0, -1)
 
 						// ? Must wait until request is reported
 						switch (typeof allowed) {


### PR DESCRIPTION
Hi! This PR addresses an issue with the Server-Timing header formatting in your server-timing middleware. The problem was that the handler metrics were being added without a trailing comma, which could lead to incorrect parsing of the header by clients. Also, it removes the trailing comma when the total is not included in the result.
